### PR TITLE
Added support for multiple inputs in config.INPUT property

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -24,15 +24,25 @@ function createConfig(doxygenOptions, configPath) {
     for (var property in doxygenOptions) {
         var configLine = property + " = ";
 
-        if (property == "OUTPUT_DIRECTORY" || property == "INPUT"){
+        if (property === "INPUT"){
+          if(Array.isArray(doxygenOptions[property])) {
+            doxygenOptions[property] = doxygenOptions[property].map(p => "\"" + path.resolve(p) + "\"")
+          }
+          else {
             doxygenOptions[property] = "\"" + path.resolve(doxygenOptions[property]) + "\"";
+          }
         }
+
+        if (property === "OUTPUT_DIRECTORY"){
+          doxygenOptions[property] = "\"" + path.resolve(doxygenOptions[property]) + "\"";
+        }
+
         if (Array.isArray(doxygenOptions[property])) {
             configLine += doxygenOptions[property].join(" \\ \n");
         } else {
             configLine += doxygenOptions[property];
         }
-        
+
         configLines.push(configLine);
     }
 

--- a/lib/execution.js
+++ b/lib/execution.js
@@ -5,7 +5,12 @@
 
 "use strict";
 
-module.exports.run = run;
+var fs = require('fs');
+
+module.exports = {
+  run: run,
+  isDoxygenExecutableInstalled: isDoxygenExecutableInstalled
+};
 
 var constants = require("./constants");
 
@@ -14,19 +19,39 @@ var path = require("path");
 
 /**
  * @ingroup Doxygen
- * Runs doxygen from node
- * @param {String} configPath - The path of the config file
- * @param {String} version - The version of doxygen to run
+ * Returns a path for doxygen executable given a version.
+ * @param {String} [version] - The version of doxygen to run.
+ *    If not passed uses default version from constants
  */
-function run(configPath, version) {
+function doxygenExecutablePath(version) {
     version = version ? version : constants.default.version;
-    configPath = configPath ? configPath : constants.path.configFile;
     var dirName = __dirname;
     var doxygenFolder = "";
     if (process.platform == constants.platform.macOS.identifier) {
         doxygenFolder = constants.path.macOsDoxygenFolder;
     }
 
-    var doxygenPath = path.normalize(dirName + "/../dist/" + version + doxygenFolder + "/doxygen");
+    return path.normalize(dirName + "/../dist/" + version + doxygenFolder + "/doxygen");
+}
+
+/**
+ * @ingroup Doxygen
+ * Returns whether a particular version of doxygen is installed.
+ * @param {String} [version] - The version of doxygen to run.
+ *    If not passed uses default version from constants
+ */
+function isDoxygenExecutableInstalled(version) {
+    var execPath = doxygenExecutablePath(version);
+    return fs.existsSync(execPath);
+}
+
+/**
+ * @ingroup Doxygen
+ * Runs doxygen from node
+ * @param {String} configPath - The path of the config file
+ * @param {String} version - The version of doxygen to run
+ */
+function run(configPath, version) {
+    var doxygenPath = doxygenExecutablePath(version);
     exec("\"" + doxygenPath + "\" \"" + path.resolve(configPath) + "\"", { stdio: ["pipe", process.stdout, "pipe"] });
 }

--- a/lib/nodeDoxygen.js
+++ b/lib/nodeDoxygen.js
@@ -10,10 +10,14 @@
 
 "use strict";
 
+var execution = require("./execution");
+
 module.exports = new NodeDoxygen();
 
+
 function NodeDoxygen() {
-    this.run = require("./execution").run;
+    this.run = execution.run;
+    this.isDoxygenExecutableInstalled = execution.isDoxygenExecutableInstalled;
     this.downloadVersion = require("./version").downloadVersion;
     this.createConfig = require("./config").createConfig;
 }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "lint": "eslint ./ --ignore-path .gitignore",
     "test": "jasmine"
   },
-  "version": "0.3.1"
+  "version": "0.3.2"
 }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "lint": "eslint ./ --ignore-path .gitignore",
     "test": "jasmine"
   },
-  "version": "0.3.0"
+  "version": "0.3.1"
 }


### PR DESCRIPTION
Hi,  Thanks for making this package. For my use case, I want to use a README.md file as the 'mainpage' of my docs and then the source is in a different subfolder. In order to do this, I need to pass multiple inputs to doxygen. It seems like config in your package would not accept an array, so I updated it to accept either array or string.