### PR TITLE
Add '.exe' extension on Windows to doxygen path

### DIFF
--- a/lib/execution.js
+++ b/lib/execution.js
@@ -31,7 +31,8 @@ function doxygenExecutablePath(version) {
         doxygenFolder = constants.path.macOsDoxygenFolder;
     }
 
-    return path.normalize(dirName + "/../dist/" + version + doxygenFolder + "/doxygen");
+    var ext = (process.platform == constants.platform.windows.identifier) ? ".exe" : "";
+    return path.normalize(dirName + "/../dist/" + version + doxygenFolder + "/doxygen" + ext);
 }
 
 /**


### PR DESCRIPTION
The `isDoxygenExecutableInstalled` function fails on Windows because the `doxygenExecutablePath` does not add the `.exe` extension for the `doxygen.exe` executable.
This PR fixes it by adding the `.exe` extension for the `doxygen` path on Windows platform.